### PR TITLE
docs(README): fix import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ HTMLST breaks down HTML documents into paragraph-like sections by taking into ac
 ```
 The following code prints out the sentences of this HTML, which is stored in `example_html_one.html`.
 ```
-from htmlst import HTMLSentenceTokenizer
+from htmlst.HTMLSentenceTokenizer import HTMLSentenceTokenizer
 
 example_html_one = open('example_html_one.html', 'r').read()
 parsed_sentences = HTMLSentenceTokenizer().feed(example_html_one)


### PR DESCRIPTION
Note: HTMLSentenceTokenizer is both a module and a class. This is confusing. Perhaps consider renaming `HTMLSentenceTokenizer.py` to `core.py`? Then add a `__init__.py` module with the line `from htmlst.core import HTMLSentenceTokenizer`. It would then work as one would expect (`from htmlst import HTMLSentenceTokenizer`)